### PR TITLE
Add URL params handling to TransitStop component

### DIFF
--- a/src/components/TransitStop.vue
+++ b/src/components/TransitStop.vue
@@ -39,6 +39,7 @@ export default {
         this.parseTripsData(tripsData);
         this.parseRoutesData(routesData);
         this.isLoading = false; // Data loaded
+        this.loadSearchFromUrl();
       })
       .catch((error) => {
         this.error = 'Error loading GTFS data';
@@ -439,6 +440,21 @@ export default {
       }
 
       selection?.removeAllRanges();
+    },
+
+    // Load search parameters from URL
+    loadSearchFromUrl() {
+      const urlParams = new URLSearchParams(window.location.search);
+      const city = urlParams.get('city');
+      const street = urlParams.get('street');
+      const radius = urlParams.get('radius');
+
+      if (city && street && radius) {
+        this.city = city;
+        this.street = street;
+        this.radius = parseInt(radius, 10);
+        this.searchLocation();
+      }
     },
   },
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import TransitStop from '../components/TransitStop.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -16,6 +17,16 @@ const router = createRouter({
       // this generates a separate chunk (About.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
       component: () => import('../views/AboutView.vue')
+    },
+    {
+      path: '/transitstop',
+      name: 'transitstop',
+      component: TransitStop,
+      props: route => ({
+        city: route.query.city,
+        street: route.query.street,
+        radius: route.query.radius
+      })
     }
   ]
 })

--- a/vite.config.ts.timestamp-1729887766421-790d80f7c6504.mjs
+++ b/vite.config.ts.timestamp-1729887766421-790d80f7c6504.mjs
@@ -1,0 +1,22 @@
+// vite.config.ts
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "file:///workspaces/transitstoplookup/node_modules/vite/dist/node/index.js";
+import vue from "file:///workspaces/transitstoplookup/node_modules/@vitejs/plugin-vue/dist/index.mjs";
+import vueJsx from "file:///workspaces/transitstoplookup/node_modules/@vitejs/plugin-vue-jsx/dist/index.mjs";
+var __vite_injected_original_import_meta_url = "file:///workspaces/transitstoplookup/vite.config.ts";
+var vite_config_default = defineConfig({
+  plugins: [
+    vue(),
+    vueJsx()
+  ],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", __vite_injected_original_import_meta_url))
+    }
+  },
+  base: "/transitstoplookup/"
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvd29ya3NwYWNlcy90cmFuc2l0c3RvcGxvb2t1cFwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiL3dvcmtzcGFjZXMvdHJhbnNpdHN0b3Bsb29rdXAvdml0ZS5jb25maWcudHNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfaW1wb3J0X21ldGFfdXJsID0gXCJmaWxlOi8vL3dvcmtzcGFjZXMvdHJhbnNpdHN0b3Bsb29rdXAvdml0ZS5jb25maWcudHNcIjtpbXBvcnQgeyBmaWxlVVJMVG9QYXRoLCBVUkwgfSBmcm9tICdub2RlOnVybCdcblxuaW1wb3J0IHsgZGVmaW5lQ29uZmlnIH0gZnJvbSAndml0ZSdcbmltcG9ydCB2dWUgZnJvbSAnQHZpdGVqcy9wbHVnaW4tdnVlJ1xuaW1wb3J0IHZ1ZUpzeCBmcm9tICdAdml0ZWpzL3BsdWdpbi12dWUtanN4J1xuXG4vLyBodHRwczovL3ZpdGVqcy5kZXYvY29uZmlnL1xuZXhwb3J0IGRlZmF1bHQgZGVmaW5lQ29uZmlnKHtcbiAgcGx1Z2luczogW1xuICAgIHZ1ZSgpLFxuICAgIHZ1ZUpzeCgpLFxuICBdLFxuICByZXNvbHZlOiB7XG4gICAgYWxpYXM6IHtcbiAgICAgICdAJzogZmlsZVVSTFRvUGF0aChuZXcgVVJMKCcuL3NyYycsIGltcG9ydC5tZXRhLnVybCkpXG4gICAgfVxuICB9LFxuICBiYXNlOiAnL3RyYW5zaXRzdG9wbG9va3VwLycsXG59KVxuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUF5USxTQUFTLGVBQWUsV0FBVztBQUU1UyxTQUFTLG9CQUFvQjtBQUM3QixPQUFPLFNBQVM7QUFDaEIsT0FBTyxZQUFZO0FBSitJLElBQU0sMkNBQTJDO0FBT25OLElBQU8sc0JBQVEsYUFBYTtBQUFBLEVBQzFCLFNBQVM7QUFBQSxJQUNQLElBQUk7QUFBQSxJQUNKLE9BQU87QUFBQSxFQUNUO0FBQUEsRUFDQSxTQUFTO0FBQUEsSUFDUCxPQUFPO0FBQUEsTUFDTCxLQUFLLGNBQWMsSUFBSSxJQUFJLFNBQVMsd0NBQWUsQ0FBQztBQUFBLElBQ3REO0FBQUEsRUFDRjtBQUFBLEVBQ0EsTUFBTTtBQUNSLENBQUM7IiwKICAibmFtZXMiOiBbXQp9Cg==


### PR DESCRIPTION
Add URL parameter handling to `TransitStop` component to load search based on city, street, and radius.

* **Router Configuration:**
  - Import `TransitStop` component in `src/router/index.ts`.
  - Add a new route for `/transitstop` with `city`, `street`, and `radius` parameters.

* **TransitStop Component:**
  - Modify `mounted` method to call `loadSearchFromUrl` method.
  - Add `loadSearchFromUrl` method to parse URL parameters and trigger `searchLocation` if parameters are present.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FriendlyUser/transitstoplookup?shareId=ae8493e1-8ec1-44f7-8de5-f61e61f57b01).